### PR TITLE
add missing include for zlib/zconf.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ FIND_PACKAGE(Torch REQUIRED)
 
 ADD_SUBDIRECTORY(zlib)
 
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/zlib)
+
 SET(src torchzlib.c)
 
 FILE(GLOB luasrc *.lua)


### PR DESCRIPTION
Explicitly include the folder where `zconf.h` is generated by [this directive](https://github.com/jonathantompson/torchzlib/blob/0e987922f46306c0dc0197f7c6df87c4a6f0b1df/zlib/CMakeLists.txt#L79).

Should fix #1 and #2.
